### PR TITLE
Add define to override disabling search engines

### DIFF
--- a/toolbox/wp-local-toolbox.php
+++ b/toolbox/wp-local-toolbox.php
@@ -9,7 +9,7 @@ if (defined('WPLT_SERVER') && WPLT_SERVER) {
 
 	If you come up with something cool I'd love a pull request!
 	 */
-	if (strtoupper(WPLT_SERVER) != 'LIVE' && strtoupper(WPLT_SERVER) != 'PRODUCTION') {
+	if (strtoupper(WPLT_SERVER) != 'LIVE' && strtoupper(WPLT_SERVER) != 'PRODUCTION') && strtoupper(WPLT_FORCE_PUBLIC) != true ) {
 		/**
 		 * Everything except PRODUCTION/LIVE Environment
 		 */


### PR DESCRIPTION
Not sure this is _the best_ option, but it follows the methodology of keeping the specific settings in wp-config.

Thoughts?
#16
